### PR TITLE
AP_Gripper: apply auto close to all backends.

### DIFF
--- a/libraries/AP_Gripper/AP_Gripper_Backend.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_Backend.cpp
@@ -1,4 +1,5 @@
 #include "AP_Gripper_Backend.h"
+#include <AP_Math/AP_Math.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -11,4 +12,11 @@ void AP_Gripper_Backend::init()
 void AP_Gripper_Backend::update()
 {
     update_gripper();
+
+    // close the gripper again if autoclose_time > 0.0
+    if (config.state == AP_Gripper::STATE_RELEASED && (_last_grab_or_release > 0) &&
+        (is_positive(config.autoclose_time)) &&
+        (AP_HAL::millis() - _last_grab_or_release > (config.autoclose_time * 1000.0))) {
+        grab();
+    }
 }

--- a/libraries/AP_Gripper/AP_Gripper_Backend.h
+++ b/libraries/AP_Gripper/AP_Gripper_Backend.h
@@ -51,5 +51,7 @@ public:
 
 protected:
 
+    uint32_t _last_grab_or_release; // ms; time last grab or release happened
+
     struct AP_Gripper::Backend_Config &config;
 };

--- a/libraries/AP_Gripper/AP_Gripper_EPM.h
+++ b/libraries/AP_Gripper/AP_Gripper_EPM.h
@@ -56,7 +56,4 @@ private:
 
     // UAVCAN driver fd
     int _uavcan_fd = -1;
-
-    // internal variables
-    uint32_t    _last_grab_or_release;
 };

--- a/libraries/AP_Gripper/AP_Gripper_Servo.h
+++ b/libraries/AP_Gripper/AP_Gripper_Servo.h
@@ -51,7 +51,5 @@ protected:
 
 private:
 
-    uint32_t action_timestamp; // ms; time grab or release happened
-
     bool has_state_pwm(const uint16_t pwm) const;
 };


### PR DESCRIPTION
This moves the auto grab code up to the backed so it applys to both EPM and Servo. To enable this I had to rename `action_timestamp` to `_last_grab_or_release` to match the variable name in EPM. I also added a `(_last_grab_or_release > 0)` check to the autoclose, this means the gripper will no longer auto close X seconds after boot. Instead it stays in the neutral position until the first actuation triggers the autoclose check.