### PR TITLE
AP_CANManager: avoid buffer-overwrite-causing-code

### DIFF
--- a/libraries/AP_CANManager/AP_CANManager.cpp
+++ b/libraries/AP_CANManager/AP_CANManager.cpp
@@ -365,6 +365,8 @@ bool AP_CANManager::register_11bit_driver(AP_CAN::Protocol dtype, CANSensor *sen
 // The result of this method can be accessed via ftp get @SYS/can_log.txt
 void AP_CANManager::log_text(AP_CANManager::LogLevel loglevel, const char *tag, const char *fmt, ...)
 {
+    return;
+
     if (_log_buf == nullptr) {
         return;
     }


### PR DESCRIPTION
### Summary

minimal fix for buffer overwrite from offset arithmetic.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

See https://github.com/ArduPilot/ardupilot/pull/33010
